### PR TITLE
Fixed Cleverreach Modus Select

### DIFF
--- a/Configuration/TsConfig/powermail.tsconfig
+++ b/Configuration/TsConfig/powermail.tsconfig
@@ -13,21 +13,22 @@ tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreach.config.item
 
 }
 
-tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreach.config.items.0 {
-  0 = ---
-  1 =
-}
+tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreach.config.items {
+  0 {
+    label = ---
+    value =
+  }
 
-tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreach.config.items.1 {
-  0 = Anmelden
-  1 = optin
-}
+  1 {
+    label = Anmelden
+    value = optin
+  }
 
-tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreach.config.items.2 {
-  0 = Abmelden
-  1 = optout
+  2 {
+    label = Abmelden
+    value = optout
+  }
 }
-
 
 tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreachFormId._sheet = main
 tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreachFormId.label = CleverReach Form ID


### PR DESCRIPTION
According to 

https://docs.typo3.org/m/typo3/reference-tca/12.4/en-us/ColumnsConfig/Type/Select/Single/Index.html#tca-example-select-single-10

select-items have the keys 'label' and 'value' instead of 0 and 1.

With this change, the select works again